### PR TITLE
Fixed foobar2000 uninstall script "chocolateyuninstall.ps1"

### DIFF
--- a/foobar2000/tools/chocolateyuninstall.ps1
+++ b/foobar2000/tools/chocolateyuninstall.ps1
@@ -11,7 +11,7 @@ if ($key.Count -eq 1) {
       fileType    = 'exe'
       silentArgs  = '/S'
       validExitCodes= @(0)
-      file          = $key.InstallLocation + "\" + "uninstall.exe"
+      file          = $_.InstallLocation + "\" + "uninstall.exe"
     }
  
     Uninstall-ChocolateyPackage @packageArgs


### PR DESCRIPTION
Filepath reference should be $_ instead of $key